### PR TITLE
Fix typo in Dockerfile causing docker build to fail

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,14 +15,14 @@ ARG GITHUB_TOKEN
 
 #================= Install dependencies
 RUN mkdir -p /mnt/vol
-COPY rplatform/dependencies.yaml rplatform/.github_access_token.txt* /mnt/vol
+COPY rplatform/dependencies.yaml rplatform/.github_access_token.txt* /mnt/vol/
 COPY rplatform/install_all_deps.R /mnt/vol/install_all_deps.R
 RUN R -f /mnt/vol/install_all_deps.R
 
 #================= Check & build package
 COPY gDRcore/ /tmp/gDRcore/
 COPY rplatform/install_repo.R /mnt/vol
-RUN R -f /mnt/vol/install_repo.R 
+RUN R -f /mnt/vol/install_repo.R
 
 #================= Clean up
 RUN sudo rm -rf /mnt/vol/* /tmp/gDRcore/


### PR DESCRIPTION
# Description
## What changed?

I fixed a typo in your Dockerfile which was causing the image to fail when calling `docker build ...`.

It now build successfully according to the instructions in the README file.