### PR TITLE
fix: create NA for ReferenceDivisionTime if doesn't exist

### DIFF
--- a/R/normalize_SE.R
+++ b/R/normalize_SE.R
@@ -69,7 +69,7 @@ normalize_SE <- function(se,
                                                    "cellline_ref_div_time", 
                                                    simplify = TRUE
                                                    )
-  if (!cell_ref_div_col %in% names(cell_ref_div_col)) {
+  if (!cell_ref_div_col %in% names(cdata)) {
     cdata[[cell_ref_div_col]] <- NA
   }
   

--- a/R/normalize_SE.R
+++ b/R/normalize_SE.R
@@ -64,14 +64,19 @@ normalize_SE <- function(se,
     ), 
     drop = FALSE
   ]
-  cl_ref_div_times <- cdata[, 
-    gDRutils::get_SE_identifiers(
-      se, 
-      "cellline_ref_div_time", 
-      simplify = TRUE
-    ), 
-    drop = FALSE
-  ]
+  
+  cell_ref_div_col <- gDRutils::get_SE_identifiers(se, 
+                                                   "cellline_ref_div_time", 
+                                                   simplify = TRUE
+                                                   )
+  if (!cell_ref_div_col %in% names(cell_ref_div_col)) {
+    cdata[[cell_ref_div_col]] <- NA
+  }
+  
+  cl_ref_div_times <- cdata[,
+                            cell_ref_div_col,
+                            drop = FALSE
+                            ]
   durations <- rdata[, 
     gDRutils::get_SE_identifiers(
       se, 


### PR DESCRIPTION
# Description
## What changed?
Related JIRA issue: 

## Why was it changed?

# Checklist for sustainable code base
- [ ] I added tests for any code changed/added
- [ ] I added documentation for any code changed/added
- [ ] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [ ] Package version bumped
- [ ] Changelog updated

# Screenshots (optional)
