### PR TITLE
Gdr 2047

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Type: Package
 Package: gDRcore
 Title: Processing functions and interface to process and analyze drug
     dose-response data
-Version: 0.99.24
-Date: 2023-06-19
+Version: 0.99.25
+Date: 2023-06-27
 Authors@R: c(
     person("Bartosz", "Czech", , "bartosz.czech@contractors.roche.com", role = "aut"),
     person("Arkadiusz", "Gladki", role=c("cre", "aut"), email="gladki.arkadiusz@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+#### [0.99.25] - 2023-06-27
+#### fix bug with missing rownames in normalized assay
+
 #### [0.99.24] - 2023-06-19
 #### update logic for merging data.table objects
 

--- a/R/normalize_SE.R
+++ b/R/normalize_SE.R
@@ -209,13 +209,13 @@ normalize_SE <- function(se,
                                    measure.vars = norm_cols,
                                    variable.name = "normalization_type",
                                    value.name = "x")
-    rownames(normalized) <- paste(
+    rownames <- paste(
       normalized$id, 
       normalized$normalization_type, 
       sep = "_"
     )
     normalized$id <- NULL
-    S4Vectors::DataFrame(normalized)
+    S4Vectors::DataFrame(normalized, row.names = rownames)
   })
   
   if (!is.null(msgs)) {

--- a/R/normalize_SE.R
+++ b/R/normalize_SE.R
@@ -164,10 +164,10 @@ normalize_SE <- function(se,
     trt_df <- data.table::as.data.table(trt_df)
     
     # Merge to ensure that the proper discard_key values are mapped.
-    all_readouts_df <- if (is.null(nested_confounders)) {
-      ref_df[trt_df, ]
-    } else {
+    all_readouts_df <- if (length(nested_confounders)) {
       ref_df[trt_df, on = nested_confounders]
+    } else {
+      ref_df[trt_df, ]
     }
 
     normalized <- data.table::data.table(

--- a/tests/testthat/test-normalize_SE.R
+++ b/tests/testthat/test-normalize_SE.R
@@ -50,4 +50,17 @@ test_that("normalize_SE works as expected", {
   se2 <- normalize_SE(se, "single-agent", nested_confounders = 
                         c(gDRutils::get_SE_identifiers(se, "barcode", simplify = TRUE), "masked"))
   expect_s4_class(se2, "SummarizedExperiment")
+  
+  
+  ctrl_df$Barcode <- NULL
+  trt_df$Barcode <- NULL
+  ctrl2 <- BumpyMatrix::splitAsBumpyMatrix(row = 1, column = 1, x = ctrl_df)
+  trted2 <- BumpyMatrix::splitAsBumpyMatrix(row = 1, column = 1, x = trt_df)
+  se3 <- SummarizedExperiment::SummarizedExperiment(assays = list("RawTreated" = trted2, "Controls" = ctrl2), 
+                                                   colData = coldata, 
+                                                   rowData = rowdata,
+                                                   metadata = metadata)
+  
+  se3 <- normalize_SE(se3, "single-agent", nested_confounders = NULL, "masked")
+  expect_s4_class(se3, "SummarizedExperiment")
 })


### PR DESCRIPTION
# Description
## What changed?
Added rownames for normalized data
Related JIRA issue: GDR-2047

## Why was it changed?
Because data.table does not support rownames

# Checklist for sustainable code base
- [ ] I added tests for any code changed/added
- [ ] I added documentation for any code changed/added
- [ ] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [X] Package version bumped
- [X] Changelog updated

# Screenshots (optional)
