### PR TITLE
Gdr 2093

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Type: Package
 Package: gDRcore
 Title: Processing functions and interface to process and analyze drug
     dose-response data
-Version: 0.99.29
-Date: 2023-07-07
+Version: 0.99.30
+Date: 2023-07-13
 Authors@R: c(
     person("Bartosz", "Czech", , "bartosz.czech@contractors.roche.com", role = "aut"),
     person("Arkadiusz", "Gladki", role=c("cre", "aut"), email="gladki.arkadiusz@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# Change to v.0.99.30 - 2023-07-13
+- fix issue with wrong merging of data.tables without nested confounders
+
 # Change to v.0.99.29 - 2023-07-07
 - add information about source type for cases without metric data
 - refactor the logic for splitting raw data from metadata (get rid of iterative approach)

--- a/R/normalize_SE.R
+++ b/R/normalize_SE.R
@@ -158,7 +158,7 @@ normalize_SE <- function(se,
     all_readouts_df <- if (length(nested_confounders)) {
       ref_df[trt_df, on = nested_confounders]
     } else {
-      ref_df[trt_df, ]
+      cbind(trt_df, ref_df)
     }
 
     normalized <- data.table::data.table(


### PR DESCRIPTION
# Description
## What changed?
Fixed issue with wrong merging data.tables without nested confounders
Related JIRA issue: GDR-2093

## Why was it changed?
To get rid of NA for RV and GR normalized values

# Checklist for sustainable code base
- [ ] I added tests for any code changed/added
- [ ] I added documentation for any code changed/added
- [ ] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [X] Package version bumped
- [X] Changelog updated

# Screenshots (optional)
