### PR TITLE
Gdr 2063

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Type: Package
 Package: gDRcore
 Title: Processing functions and interface to process and analyze drug
     dose-response data
-Version: 0.99.30
-Date: 2023-07-13
+Version: 0.99.31
+Date: 2023-07-19
 Authors@R: c(
     person("Bartosz", "Czech", , "bartosz.czech@contractors.roche.com", role = "aut"),
     person("Arkadiusz", "Gladki", role=c("cre", "aut"), email="gladki.arkadiusz@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# Change to v.0.99.31 - 2023-07-19
+- update the logic for handling warnings in the pipeline
+
 # Change to v.0.99.30 - 2023-07-13
 - fix issue with wrong merging of data.tables without nested confounders
 

--- a/R/pipeline_helpers.R
+++ b/R/pipeline_helpers.R
@@ -161,6 +161,10 @@ read_intermediate_data <- function(path, step, experiment) {
 
 #' @keywords internal
 paste_warnings <- function(list, sep = "\n") {
-  pasted <- paste0(list, sep = sep)
-  warning(pasted, call. = FALSE)
+  if (length(list)) {
+    pasted <- paste0(list, sep = sep)
+    warning(pasted, call. = FALSE)
+  } else {
+    invisible(NULL)
+  }
 }

--- a/tests/testthat/test-finalMAE_medium.R
+++ b/tests/testthat/test-finalMAE_medium.R
@@ -6,7 +6,7 @@ test_that("medium: test_synthetic_data", {
   mae <- purrr::quietly(generateMediumData)(
     cell_lines, drugs, FALSE
   )
-  expect_length(mae$warnings, 3)
+  expect_length(mae$warnings, 2)
   
   test_synthetic_data(original, mae$result, data)
 })

--- a/tests/testthat/test-finalMAE_small_no_noise.R
+++ b/tests/testthat/test-finalMAE_small_no_noise.R
@@ -6,7 +6,7 @@ test_that("small_no_noise: test_synthetic_data", {
   mae <- purrr::quietly(generateNoNoiseRawData)(
     cell_lines, drugs, FALSE
   )
-  expect_length(mae$warnings, 3)
+  expect_length(mae$warnings, 2)
 
   test_synthetic_data(original, mae$result, data)
 })

--- a/tests/testthat/test-finalMAE_wLigand.R
+++ b/tests/testthat/test-finalMAE_wLigand.R
@@ -6,7 +6,7 @@ test_that("wLigand: test_synthetic_data", {
   mae <- purrr::quietly(generateLigandData)(
     cell_lines, drugs, FALSE
   )
-  expect_length(mae$warnings, 3)
+  expect_length(mae$warnings, 2)
   
   test_synthetic_data(original, mae$result, data)
 })

--- a/tests/testthat/test-masked_unmasked.R
+++ b/tests/testthat/test-masked_unmasked.R
@@ -19,7 +19,7 @@ test_that("masked and unmasked values are processed properly", {
     override_untrt_controls = NULL,
     nested_confounders = gDRutils::get_env_identifiers("barcode")[1]
   )
-  expect_length(finalMAE$warnings, 3)
+  expect_length(finalMAE$warnings, 2)
   
   testthat::expect_s4_class(finalMAE$result, "MultiAssayExperiment")
 })

--- a/tests/testthat/test-runDrugResponseProcessingPipeline.R
+++ b/tests/testthat/test-runDrugResponseProcessingPipeline.R
@@ -39,7 +39,7 @@ test_that("main pipeline functions works as expected", {
     data_dir = p_dir
   )
   expect_true(length(list.files(p_dir)) > 0)
-  expect_length(mae_v1$warnings, 3)
+  expect_length(mae_v1$warnings, 2)
 
   mae_v2 <-
     purrr::quietly(runDrugResponseProcessingPipeline)(
@@ -58,13 +58,13 @@ test_that("main pipeline functions works as expected", {
       start_from = "normalize_SE",
       selected_experiments = c("single-agent")
     )
-  expect_length(mae_v3$warnings, 3)
+  expect_length(mae_v3$warnings, 2)
 
   mae_v4 <-
     purrr::quietly(runDrugResponseProcessingPipeline)(
       mae_v1$result
     )
-  expect_length(mae_v4$warnings, 4)
+  expect_length(mae_v4$warnings, 3)
 
   expect_identical(mae_v1$result, mae_v2$result)
   expect_identical(mae_v2$result, mae_v3$result)


### PR DESCRIPTION
# Description
## What changed? Update the logic for managing warnings in the pipeline script
Related JIRA issue: GDR-2063

## Why was it changed?
To get rid of empty warnings

# Checklist for sustainable code base
- [ ] I added tests for any code changed/added
- [ ] I added documentation for any code changed/added
- [ ] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [X] Package version bumped
- [X] Changelog updated

# Screenshots (optional)
