### PR TITLE
changes in calculation for GR values - cover a common case

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Type: Package
 Package: gDRcore
 Title: Processing functions and interface to process and analyze drug
     dose-response data
-Version: 0.99.35
-Date: 2023-08-17
+Version: 0.99.36
+Date: 2023-09-01
 Authors@R: c(
     person("Bartosz", "Czech", , "bartosz.czech@contractors.roche.com", role = "aut"),
     person("Arkadiusz", "Gladki", role=c("cre", "aut"), email="gladki.arkadiusz@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# Change to v.0.99.36 - 2023-09-01
+- fill NA during aggregation of ref and trt data with mean
+
 # Change to v.0.99.35 - 2023-08-17
 - fix issue with missing subsetting Day0 data
 

--- a/R/calculate_GR_value.R
+++ b/R/calculate_GR_value.R
@@ -110,7 +110,6 @@ calculate_GR_value <- function(rel_viability,
       untrt_readout, 
       ndigit_rounding)
   }
-  
   GRvalue
 }
 

--- a/R/calculate_GR_value.R
+++ b/R/calculate_GR_value.R
@@ -85,9 +85,10 @@ calculate_GR_value <- function(rel_viability,
       corrected_readout, day0_readout, untrt_readout"
     )
   }
-
+  
   # TODO: Is it correct to put the 'any' here?
-  if (any(!is.na(day0_readout))) {
+  # Note: we should back-calculate only if we cannot use the day0_readout (i.e. line by line)
+  if (any(is.na(day0_readout))) {
     ## Back-calculate the day0_readout using the reference doubling time 
     ## and the duration of treatment.
     GRvalue <- if (is.null(ref_div_time) || is.na(ref_div_time)) {
@@ -109,6 +110,7 @@ calculate_GR_value <- function(rel_viability,
       untrt_readout, 
       ndigit_rounding)
   }
+  
   GRvalue
 }
 

--- a/R/calculate_GR_value.R
+++ b/R/calculate_GR_value.R
@@ -87,7 +87,7 @@ calculate_GR_value <- function(rel_viability,
   }
 
   # TODO: Is it correct to put the 'any' here?
-  if (any(is.na(day0_readout))) {
+  if (any(!is.na(day0_readout))) {
     ## Back-calculate the day0_readout using the reference doubling time 
     ## and the duration of treatment.
     GRvalue <- if (is.null(ref_div_time) || is.na(ref_div_time)) {

--- a/R/normalize_SE.R
+++ b/R/normalize_SE.R
@@ -152,6 +152,12 @@ normalize_SE <- function(se,
     # (uses mean across all available values)
     
     ref_df <- aggregate_ref(ref_df, control_mean_fxn = control_mean_fxn)
+    
+    # Backfill missing values when the `nested_keys` are not matching. 
+    # This is necessary for Day0 data that are collected on another plate
+    ref_df$Day0Readout[is.na(ref_df$Day0Readout)] = mean(ref_df$Day0Readout[!is.na(ref_df$Day0Readout)])
+    ref_df$UntrtReadout[is.na(ref_df$UntrtReadout)] = mean(ref_df$UntrtReadout[!is.na(ref_df$UntrtReadout)])
+    
     trt_df <- data.table::as.data.table(trt_df)
     
     # Merge to ensure that the proper discard_key values are mapped.

--- a/R/normalize_SE.R
+++ b/R/normalize_SE.R
@@ -152,12 +152,13 @@ normalize_SE <- function(se,
     # (uses mean across all available values)
     
     ref_df <- aggregate_ref(ref_df, control_mean_fxn = control_mean_fxn)
-    
-    # Backfill missing values when the `nested_keys` are not matching. 
+
+    # Backfill missing values with an average of the other plates
     # This is necessary for Day0 data that are collected on another plate
-    ref_df$Day0Readout[is.na(ref_df$Day0Readout)] = mean(ref_df$Day0Readout[!is.na(ref_df$Day0Readout)])
-    ref_df$UntrtReadout[is.na(ref_df$UntrtReadout)] = mean(ref_df$UntrtReadout[!is.na(ref_df$UntrtReadout)])
+    ref_df$Day0Readout[is.na(ref_df$Day0Readout)] <- mean(ref_df$Day0Readout[!is.na(ref_df$Day0Readout)])
+    ref_df$UntrtReadout[is.na(ref_df$UntrtReadout)] <- mean(ref_df$UntrtReadout[!is.na(ref_df$UntrtReadout)])
     
+    print(ref_df)
     trt_df <- data.table::as.data.table(trt_df)
     
     # Merge to ensure that the proper discard_key values are mapped.
@@ -167,6 +168,11 @@ normalize_SE <- function(se,
       cbind(trt_df, ref_df)
     }
 
+    # Backfill missing values when the `nested_keys` are not matching with an average. 
+    # This is necessary if a control is only present on another plate
+    all_readouts_df$Day0Readout[is.na(all_readouts_df$Day0Readout)] <- mean(ref_df$Day0Readout[!is.na(ref_df$Day0Readout)])
+    all_readouts_df$UntrtReadout[is.na(all_readouts_df$UntrtReadout)] <- mean(ref_df$UntrtReadout[!is.na(ref_df$UntrtReadout)])
+    print(all_readouts_df)
     normalized <- data.table::data.table(
       matrix(NA, nrow = nrow(trt_df), ncol = length(norm_cols))
     )
@@ -188,7 +194,7 @@ normalize_SE <- function(se,
       duration = duration,
       ref_div_time = ref_div_time
     )
-
+    
     if (any(is.na(all_readouts_df$Day0Readout))) {
       msgs <- c(msgs,
                 sprintf("could not calculate GR values for '%s'", cl_name))

--- a/R/normalize_SE.R
+++ b/R/normalize_SE.R
@@ -240,8 +240,9 @@ aggregate_ref <- function(ref_df, control_mean_fxn) {
 fill_NA_by_mean <- function(dt, cols) {
   dt2 <- data.table::copy(dt)
   dt2[, (cols) :=
-       lapply(.SD, function(x) ifelse(is.na(x),
-                                      mean(x, na.rm = TRUE), x)),
+       lapply(.SD, function(x) {
+         ifelse(is.na(x), mean(x, na.rm = TRUE), x)
+         }),
      .SDcols = cols]
   dt2
 }

--- a/R/normalize_SE.R
+++ b/R/normalize_SE.R
@@ -158,7 +158,6 @@ normalize_SE <- function(se,
     ref_df$Day0Readout[is.na(ref_df$Day0Readout)] <- mean(ref_df$Day0Readout[!is.na(ref_df$Day0Readout)])
     ref_df$UntrtReadout[is.na(ref_df$UntrtReadout)] <- mean(ref_df$UntrtReadout[!is.na(ref_df$UntrtReadout)])
     
-    print(ref_df)
     trt_df <- data.table::as.data.table(trt_df)
     
     # Merge to ensure that the proper discard_key values are mapped.
@@ -172,7 +171,7 @@ normalize_SE <- function(se,
     # This is necessary if a control is only present on another plate
     all_readouts_df$Day0Readout[is.na(all_readouts_df$Day0Readout)] <- mean(ref_df$Day0Readout[!is.na(ref_df$Day0Readout)])
     all_readouts_df$UntrtReadout[is.na(all_readouts_df$UntrtReadout)] <- mean(ref_df$UntrtReadout[!is.na(ref_df$UntrtReadout)])
-    print(all_readouts_df)
+    
     normalized <- data.table::data.table(
       matrix(NA, nrow = nrow(trt_df), ncol = length(norm_cols))
     )

--- a/R/normalize_SE.R
+++ b/R/normalize_SE.R
@@ -150,7 +150,7 @@ normalize_SE <- function(se,
 
     # pad the ref_df for missing values based on nested_keys 
     # (uses mean across all available values)
-    
+    control_types <- unique(ref_df$control_type)
     ref_df <- aggregate_ref(ref_df, control_mean_fxn = control_mean_fxn)
     trt_df <- data.table::as.data.table(trt_df)
     
@@ -163,9 +163,7 @@ normalize_SE <- function(se,
 
     # Backfill missing values when the `nested_keys` are not matching with an average. 
     # This is necessary if a control is only present on another plate
-    all_readouts_df$Day0Readout[is.na(all_readouts_df$Day0Readout)] <- mean(ref_df$Day0Readout[!is.na(ref_df$Day0Readout)])
-    all_readouts_df$UntrtReadout[is.na(all_readouts_df$UntrtReadout)] <- mean(ref_df$UntrtReadout[!is.na(ref_df$UntrtReadout)])
-    
+    all_readouts_df <- fill_NA_by_mean(all_readouts_df, control_types)
     normalized <- data.table::data.table(
       matrix(NA, nrow = nrow(trt_df), ncol = length(norm_cols))
     )

--- a/tests/testthat/test-normalize_SE.R
+++ b/tests/testthat/test-normalize_SE.R
@@ -64,3 +64,25 @@ test_that("normalize_SE works as expected", {
   se3 <- normalize_SE(se3, "single-agent", nested_confounders = NULL, "masked")
   expect_s4_class(se3, "SummarizedExperiment")
 })
+
+
+test_that("merge_trt_with_ref and aggregate_ref works as expected with Day0data", {
+  ref_df <- data.table::data.table(control_type = c("Day0Readout", "UntrtReadout"),
+                                   CorrectedReadout = c(215102, 655570),
+                                   Barcode = c("230815_1", "230815_3"),
+                                   isDay0 = c(TRUE, FALSE))
+  trt_df <- data.table::data.table(Concentration = 0.00457247142398638,
+                                   Barcode = "230815_3",
+                                   ReadoutValue = 601116,
+                                   BackgroundValue = 0,
+                                   masked = FALSE,
+                                   CorrectedReadout = 601116)
+  agg_ref <- aggregate_ref(ref_df, mean)
+  merged_trt_ref <- merge_trt_with_ref(ref_df, trt_df, "Barcode", mean)
+  
+  expect_true(all(!is.na(agg_ref$Day0Readout)))
+  expect_true(all(!is.na(agg_ref$UntrtReadout)))
+  
+  expect_true(all(!is.na(merged_trt_ref$Day0Readout)))
+  expect_true(all(!is.na(merged_trt_ref$UntrtReadout)))
+})


### PR DESCRIPTION
# Description
## What changed?
Related JIRA issue: 
https://jira.gene.com/jira/projects/GDR/issues/GDR-2155

## Why was it changed?
I found that the matching of the control by `Barcode` (or other nested `nested_keys`) is too stringent. In case there is a value for another plate, we should backfill it. This is important as Day0 plate will have another barcode by design but they are meant to be used for normalization.

# Checklist for sustainable code base
- [ ] I added tests for any code changed/added
- [ ] I added documentation for any code changed/added
- [ ] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [ ] Package version bumped
- [ ] Changelog updated

# Screenshots (optional)
