### PR TITLE
Gdr 2127

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Type: Package
 Package: gDRcore
 Title: Processing functions and interface to process and analyze drug
     dose-response data
-Version: 0.99.37
-Date: 2023-09-04
+Version: 0.99.38
+Date: 2023-09-12
 Authors@R: c(
     person("Bartosz", "Czech", , "bartosz.czech@contractors.roche.com", role = "aut"),
     person("Arkadiusz", "Gladki", role=c("cre", "aut"), email="gladki.arkadiusz@gmail.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# Change to v.0.99.38 - 2023-09-12
+- set Drug3 as an official tertiary drug in the experiment
+
 # Change to v.0.99.37 - 2023-09-04
 - fill NA by average values when there is no match with plate
 

--- a/R/convert_se_to_raw_data.R
+++ b/R/convert_se_to_raw_data.R
@@ -92,8 +92,7 @@ convert_se_to_raw_data <- function(se) {
   data.table::setnames(merged_df, "CorrectedReadout", "ReadoutValue")
   
   exp_metadata <- gDRutils::get_SE_experiment_metadata(se)
-
-  cbind(na.omit(merged_df, col = "ReadoutValue"), data.table::as.data.table(exp_metadata))
+  na.omit(merged_df, col = "ReadoutValue")
 }
 
 

--- a/R/data_type.R
+++ b/R/data_type.R
@@ -44,13 +44,13 @@ identify_data_type <- function(df,
   
   # find the pairs of drugs with relevant metadata
   drug_ids <- unlist(gDRutils::get_env_identifiers(
-    c("drug_name", "drug_name2"), 
+    c("drug_name", "drug_name2", "drug_name3"), 
     simplify = FALSE
   )) 
   drugs_ids <- drug_ids[which(drug_ids %in% names(df))]
   
   conc_ids <- unlist(gDRutils::get_env_identifiers(
-    c("concentration", "concentration2"), 
+    c("concentration", "concentration2", "concentration3"), 
     simplify = FALSE
   ))
   conc_ids <- conc_ids[which(conc_ids %in% names(df))]
@@ -189,8 +189,9 @@ split_raw_data <- function(df,
                            type_col = "type") {
   
   drug_ids <- unlist(gDRutils::get_env_identifiers(
-    c("drug_name", "drug_name2", "drug", "drug2",
-      "drug_moa", "drug_moa2", "concentration", "concentration2"), 
+    c("drug_name", "drug_name2", "drug_name3", "drug", "drug2", "drug3",
+      "drug_moa", "drug_moa2", "drug_moa3", "concentration", "concentration2",
+      "concentration3"), 
     simplify = FALSE)
   ) 
   drug_ids <- drug_ids[which(drug_ids %in% names(df))]


### PR DESCRIPTION
# Description
## What changed?
Set Drug3 as a tertiary drug
Related JIRA issue: GDR-2127

## Why was it changed?
To switch from Drug3 treated as an additional perturbation to the official tertiary drug

# Checklist for sustainable code base
- [ ] I added tests for any code changed/added
- [ ] I added documentation for any code changed/added
- [ ] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [X] Package version bumped
- [X] Changelog updated

# Screenshots (optional)
