### PR TITLE
Gdr 2218

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Type: Package
 Package: gDRcore
 Title: Processing functions and interface to process and analyze drug
     dose-response data
-Version: 0.99.41
-Date: 2023-09-25
+Version: 0.99.42
+Date: 2023-10-05
 Authors@R: c(
     person("Bartosz", "Czech", , "bartosz.czech@contractors.roche.com", role = "aut"),
     person("Arkadiusz", "Gladki", role=c("cre", "aut"), email="gladki.arkadiusz@gmail.com"),
@@ -35,7 +35,7 @@ Suggests:
     BiocStyle,
     gDRstyle (>= 0.99.15),
     gDRimport (>= 0.99.10),
-    gDRtestData (>= 0.99.13),
+    gDRtestData (>= 0.99.20),
     IRanges,
     knitr,
     pkgbuild,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# Change to v.0.99.42 - 2023-10-05
+- bump version of gDRtestData
+- fix bug with merging controls in triple combo with additional perturbations
+
 # Change to v.0.99.41 - 2023-09-25
 - add support for adding custom annotations inside input files
 - improve the performance

--- a/R/data_type.R
+++ b/R/data_type.R
@@ -184,7 +184,7 @@ split_raw_data <- function(df,
           control[[cl]] %in% unique_cotrt[[cl]] &
             control[[drug_ids[["drug_name"]]]] %in% untreated_tag, 
         ][, colnames, with = FALSE])
-      cotrt_matching <- rbind(unique_cotrt, unique_cotrt_ctrl)
+      cotrt_matching <- unique(rbind(unique_cotrt, unique_cotrt_ctrl))
     df_merged <- rbind(
         df_list[[x]], 
         cotrt_matching[control, on = intersect(names(cotrt_matching), names(control))])

--- a/rplatform/dependencies.yaml
+++ b/rplatform/dependencies.yaml
@@ -7,7 +7,7 @@ pkgs:
     host: 'api.github.com'
     source: GITHUB
   gDRtestData:
-    ver: '>=0.99.13'
+    ver: '>=0.99.20'
     url: gdrplatform/gDRtestData
     ref: master
     subdir: ~


### PR DESCRIPTION
# Description
## What changed?
Related JIRA issue: GDR-2218

## Why was it changed?
To fix bug in gDRin for triple combo data with additional perturbations that have duplicated keys for controls

# Checklist for sustainable code base
- [ ] I added tests for any code changed/added
- [ ] I added documentation for any code changed/added
- [ ] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [X] Package version bumped
- [X] Changelog updated

# Screenshots (optional)
