### PR TITLE
[GDR-2227] Treatment instead of template

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Type: Package
 Package: gDRcore
 Title: Processing functions and interface to process and analyze drug
     dose-response data
-Version: 0.99.43
-Date: 2023-10-17
+Version: 0.99.44
+Date: 2023-10-24
 Authors@R: c(
     person("Bartosz", "Czech", , "bartosz.czech@contractors.roche.com", role = "aut"),
     person("Arkadiusz", "Gladki", role=c("cre", "aut"), email="gladki.arkadiusz@gmail.com"),
@@ -25,7 +25,7 @@ Imports:
     BiocParallel,
     checkmate,
     futile.logger,
-    gDRutils (>= 0.99.28),
+    gDRutils (>= 0.99.34),
     MultiAssayExperiment,
     purrr,
     stringr,    
@@ -35,7 +35,7 @@ Imports:
 Suggests:
     BiocStyle,
     gDRstyle (>= 0.99.15),
-    gDRimport (>= 0.99.10),
+    gDRimport (>= 0.99.26),
     gDRtestData (>= 0.99.20),
     IRanges,
     knitr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 0.99.44 (2023-10-24)
+- add "Treatment" as template identifier
+
 ## 0.99.43 (2023-10-17)
 - adjust NEWS to Bioc format
 

--- a/man/gDRcore-package.Rd
+++ b/man/gDRcore-package.Rd
@@ -24,6 +24,7 @@ Authors:
   \item Pawel Piatkowski
   \item Natalia Potocka
   \item Dariusz Scigocki
+  \item Janina Smola
   \item Sergiu Mocanu
   \item Allison Vuong
 }

--- a/rplatform/dependencies.yaml
+++ b/rplatform/dependencies.yaml
@@ -1,6 +1,6 @@
 pkgs:
   gDRutils:
-    ver: '>=0.99.28'
+    ver: '>=0.99.34'
     url: gdrplatform/gDRutils
     ref: master
     subdir: ~
@@ -21,8 +21,8 @@ pkgs:
     host: 'api.github.com'
     source: GITHUB
   gDRimport:
-    ver: '>=0.99.10'
-    url: gdrplatform/gDRstyle
+    ver: '>=0.99.26'
+    url: gdrplatform/gDRimport
     ref: main
     subdir: ~
     host: 'api.github.com'


### PR DESCRIPTION
# Description
## What changed?
Related JIRA issue: [GDR-2227](https://jira.gene.com/jira/browse/GDR-2227)

## Why was it changed?
`Treatment` is more readable for users than `Template`.

# Checklist for sustainable code base
- [ ] I added tests for any code changed/added
- [ ] I added documentation for any code changed/added
- [ ] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [x] Package version bumped
- [x] Changelog updated

# Screenshots (optional)
