### PR TITLE
bugfix: resolve issue with non-avearaged concentration data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Type: Package
 Package: gDRcore
 Title: Processing functions and interface to process and analyze drug
     dose-response data
-Version: 1.3.6
-Date: 2024-07-23
+Version: 1.3.7
+Date: 2024-08-05
 Authors@R: c(
     person("Bartosz", "Czech", , "bartosz.czech@contractors.roche.com", role = "aut",
            comment = c(ORCID = "0000-0002-9908-3007")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## gDRcore 1.3.7 - 2024-08-05
+* fix issue with non-avearaged concentration data
+
 ## gDRcore 1.3.6 - 2024-07-23
 * fix issue with providing empty nested_confounder
 

--- a/R/fit_SE.combinations.R
+++ b/R/fit_SE.combinations.R
@@ -140,7 +140,7 @@ fit_SE.combinations <- function(se,
   
     for (norm_type in normalization_types) {
 
-      # use data.tablea with averaged concentration values 
+      # use data.table with averaged concentration values 
       # (if some duplicates appeared after mapping to standardized concentrations)
       avg_combo <- data.table::as.data.table(mean_avg_combo)
       avg_subset <- avg_combo[normalization_type == norm_type]

--- a/R/fit_SE.combinations.R
+++ b/R/fit_SE.combinations.R
@@ -140,7 +140,9 @@ fit_SE.combinations <- function(se,
   
     for (norm_type in normalization_types) {
 
-      avg_combo <- data.table::as.data.table(avg_combo)
+      # use data.tablea with averaged concentration values 
+      # (if some duplicates appeared after mapping to standardized concentrations)
+      avg_combo <- data.table::as.data.table(mean_avg_combo)
       avg_subset <- avg_combo[normalization_type == norm_type]
       complete_subset <- complete[normalization_type == norm_type | is.na(normalization_type)]
       complete_subset[is.na(normalization_type), normalization_type := norm_type]

--- a/R/fit_SE.combinations.R
+++ b/R/fit_SE.combinations.R
@@ -112,7 +112,8 @@ fit_SE.combinations <- function(se,
       "rconcs"
     )
     
-    mean_avg_combo <-  avg_combo[, lapply(.SD, mean), by = c(id, id2, "normalization_type"), .SDcols = "x"]
+    mean_avg_combo <-  avg_combo[, lapply(.SD, mean), by = c(id, id2, "normalization_type"), .SDcols = c("x", "x_std")]
+
     # deal with cases of multiple concentrations mapped to the same value 
     # when rounded create a complete matrix with the most frequence combo 
     # concentrations


### PR DESCRIPTION
# Description
bugfix: resolve an issue with non-averaged concentration data
## What changed?
updated logic to handle properly concentration data if duplications appear after mapping to standardized concentrations
Related JIRA issue:  GDR-2633

## Why was it changed?
bugfix: resolve an issue with non-averaged concentration data

# Checklist for sustainable code base
- [ ] I added tests for any code changed/added
- [ ] I added documentation for any code changed/added
- [ ] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [X] Package version bumped
- [X] Changelog updated

# Screenshots (optional)
