### PR TITLE
chore: migrate from qs to qs2 package (GDR-3351)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: gDRcore
 Title: Processing functions and interface to process and analyze drug
     dose-response data
-Version: 1.9.6
+Version: 1.9.7
 Date: 2026-02-18
 Authors@R: c(
     person("Bartosz", "Czech", , "bartosz.czech@contractors.roche.com", role = "aut",
@@ -44,7 +44,7 @@ Suggests:
     IRanges,
     knitr,
     pkgbuild,
-    qs,
+    qs2,
     testthat,
     yaml
 VignetteBuilder: 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## gDRcore 1.9.7 - 2026-04-13
+* migrate from `qs` to `qs2` package (`qs::qread` → `qs2::qs_read`, `qs::qsave` → `qs2::qs_save`)
+* update checkpoint and generated data file extensions from `.qs` to `.qs2`
+
 ## gDRcore 1.9.6 - 2026-02-18
 * fix handling of numeric identifiers in annotation functions
 

--- a/R/generate_wrappers.R
+++ b/R/generate_wrappers.R
@@ -16,7 +16,7 @@ generateNoNoiseRawData <- function(cell_lines, drugs, save = TRUE) {
   if (save) {
     save_qs(
       qsObj = mae,
-      qsName = "finalMAE_small_no_noise.qs"
+      qsName = "finalMAE_small_no_noise.qs2"
     )
   }
   invisible(mae)
@@ -39,7 +39,7 @@ generateNoiseRawData <- function(cell_lines, drugs, save = TRUE) {
   if (save) {
     save_qs(
       qsObj = mae,
-      qsName = "finalMAE_small.qs"
+      qsName = "finalMAE_small.qs2"
     )
   }
   invisible(mae)
@@ -75,7 +75,7 @@ generateLigandData <- function(cell_lines, drugs, save = TRUE) {
   if (save) {
     save_qs(
       qsObj = mae,
-      qsName = "finalMAE_wLigand.qs"
+      qsName = "finalMAE_wLigand.qs2"
     )
   }
   invisible(mae)
@@ -97,7 +97,7 @@ generateMediumData <- function(cell_lines, drugs, save = TRUE) {
   if (save) {
     save_qs(
       qsObj = mae,
-      qsName = "finalMAE_medium.qs"
+      qsName = "finalMAE_medium.qs2"
     )
   }
   invisible(mae)
@@ -121,7 +121,7 @@ generateComboNoNoiseData <- function(cell_lines, drugs, save = TRUE) {
   if (save) {
     save_qs(
       qsObj = mae,
-      qsName = "finalMAE_combo_2dose_nonoise.qs"
+      qsName = "finalMAE_combo_2dose_nonoise.qs2"
     )
   }
   invisible(mae)
@@ -146,7 +146,7 @@ generateComboNoNoiseData2 <- function(cell_lines, drugs, save = TRUE) {
   if (save) {
     save_qs(
       qsObj = mae,
-      qsName = "finalMAE_combo_2dose_nonoise2.qs"
+      qsName = "finalMAE_combo_2dose_nonoise2.qs2"
     )
   }
   invisible(mae)
@@ -175,7 +175,7 @@ generateComboNoNoiseData3 <- function(cell_lines, drugs, save = TRUE) {
   if (save) {
     save_qs(
       qsObj = mae,
-      qsName = "finalMAE_combo_2dose_nonoise3.qs"
+      qsName = "finalMAE_combo_2dose_nonoise3.qs2"
     )
   }
   invisible(mae)
@@ -204,7 +204,7 @@ generateComboMatrixSmall <- function(cell_lines, drugs, save = TRUE) {
   if (save) {
     save_qs(
       qsObj = mae,
-      qsName = "finalMAE_combo_matrix_small.qs"
+      qsName = "finalMAE_combo_matrix_small.qs2"
     )
   }
   invisible(mae)
@@ -232,7 +232,7 @@ generateComboMatrix <- function(cell_lines, drugs, save = TRUE) {
   if (save) {
     save_qs(
       qsObj = mae,
-      qsName = "finalMAE_combo_matrix.qs"
+      qsName = "finalMAE_combo_matrix.qs2"
     )
   }
   invisible(mae)
@@ -277,7 +277,7 @@ df_layout_3 <- df_layout[df_2, on = intersect(names(df_layout), names(df_2)),
   if (save) {
     save_qs(
       qsObj = mae,
-      qsName = "finalMAE_combo_triple.qs"
+      qsName = "finalMAE_combo_triple.qs2"
     )
   }
   invisible(mae)
@@ -301,7 +301,7 @@ generateCodilutionSmall <- function(cell_lines, drugs, save = TRUE) {
   if (save) {
     save_qs(
       qsObj = mae,
-      qsName = "finalMAE_combo_codilution_small.qs"
+      qsName = "finalMAE_combo_codilution_small.qs2"
     )
   }
   invisible(mae)
@@ -325,7 +325,7 @@ generateCodilution <- function(cell_lines, drugs, save = TRUE) {
   if (save) {
     save_qs(
       qsObj = mae,
-      qsName = "finalMAE_combo_codilution.qs"
+      qsName = "finalMAE_combo_codilution.qs2"
     )
   }
   
@@ -334,7 +334,7 @@ generateCodilution <- function(cell_lines, drugs, save = TRUE) {
 
 #' @keywords internal
 save_qs <- function(qsObj, qsName) {
-  qs::qsave(
+  qs2::qs_save(
     qsObj,
     file.path(system.file("testdata", package = "gDRtestData"), qsName)
   )

--- a/R/pipeline_helpers.R
+++ b/R/pipeline_helpers.R
@@ -121,9 +121,9 @@ is_preceding_step <-
     s_idx - c_idx == 1
   }
 
-#' save intermediate data for the given experiment and step to qs file
-#' 
-#' @param path string with the save directory for the qs file 
+#' save intermediate data for the given experiment and step to qs2 file
+#'
+#' @param path string with the save directory for the qs2 file
 #' @param step, string with the step name
 #' @param experiment string with the experiment name
 #' @param se output se 
@@ -145,9 +145,9 @@ save_intermediate_data <- function(path, step, experiment, se) {
   qs2::qs_save(se, fpath)
 }
 
-#' read intermediate data for the given experiment and step to qs file
-#' 
-#' @param path string with the input directory of the qs file 
+#' read intermediate data for the given experiment and step to qs2 file
+#'
+#' @param path string with the input directory of the qs2 file
 #' @param step, string with the step name
 #' @param experiment string with the experiment name
 #' 

--- a/R/pipeline_helpers.R
+++ b/R/pipeline_helpers.R
@@ -133,11 +133,14 @@ is_preceding_step <-
 #' @return \code{NULL}
 #' 
 save_intermediate_data <- function(path, step, experiment, se) {
-  
+
+  if (!requireNamespace("qs2", quietly = TRUE)) {
+    stop("Package 'qs2' is required for saving intermediate data. Please install it.")
+  }
   checkmate::assert_directory(path, "rw")
   checkmate::assert_string(step)
   checkmate::assert_string(experiment)
-  
+
   fpath <- file.path(path, paste0(experiment, "__", step, ".qs2"))
   qs2::qs_save(se, fpath)
 }
@@ -152,11 +155,14 @@ save_intermediate_data <- function(path, step, experiment, se) {
 #' @return se
 #' 
 read_intermediate_data <- function(path, step, experiment) {
-  
+
+  if (!requireNamespace("qs2", quietly = TRUE)) {
+    stop("Package 'qs2' is required to read intermediate data. Please install it.")
+  }
   checkmate::assert_directory(path, "r")
   checkmate::assert_string(step)
   checkmate::assert_string(experiment)
-  
+
   fpath <- file.path(path, paste0(experiment, "__", step, ".qs2"))
   qs2::qs_read(fpath)
 }

--- a/R/pipeline_helpers.R
+++ b/R/pipeline_helpers.R
@@ -138,8 +138,8 @@ save_intermediate_data <- function(path, step, experiment, se) {
   checkmate::assert_string(step)
   checkmate::assert_string(experiment)
   
-  fpath <- file.path(path, paste0(experiment, "__", step, ".qs"))
-  qs::qsave(se, fpath)
+  fpath <- file.path(path, paste0(experiment, "__", step, ".qs2"))
+  qs2::qs_save(se, fpath)
 }
 
 #' read intermediate data for the given experiment and step to qs file
@@ -157,8 +157,8 @@ read_intermediate_data <- function(path, step, experiment) {
   checkmate::assert_string(step)
   checkmate::assert_string(experiment)
   
-  fpath <- file.path(path, paste0(experiment, "__", step, ".qs"))
-  qs::qread(fpath)
+  fpath <- file.path(path, paste0(experiment, "__", step, ".qs2"))
+  qs2::qs_read(fpath)
 }
 
 #' @keywords internal

--- a/R/runDrugResponseProcessingPipeline.R
+++ b/R/runDrugResponseProcessingPipeline.R
@@ -55,7 +55,7 @@
 #' relative viability at.
 #' @param curve_type vector of curve type values.
 #' @param data_dir string with the path to the directory with intermediate data 
-#' of experiments (qs files). If set to NULL (default) intermediate data is not 
+#' of experiments (qs2 files). If set to NULL (default) intermediate data is not
 #' saved/read in.
 #' @param partial_run logical flag indicating if the pipeline should be run 
 #' partially (from the step defined with `start_from`)
@@ -91,8 +91,8 @@
 #' Pipeline can be run partially with `partial_run` flag set to TRUE. The 
 #' `start_from` string defines the step from which the pipeline will be 
 #' launched. However, partial run of the pipeline is possible only if the whole
-#' pipeline was launched at least once with defined `data_dir` and intermediate 
-#' data was saved as qs files into `data_dir`. 
+#' pipeline was launched at least once with defined `data_dir` and intermediate
+#' data was saved as qs2 files into `data_dir`. 
 #' 
 #' Pipeline can be run for the selected experiments by changing the default 
 #' value of `selected_experiments` param. This scenario only works when 

--- a/R/utils.R
+++ b/R/utils.R
@@ -539,8 +539,8 @@ get_assays_per_pipeline_step <-
     ass
   }
 
-#' add intermediate data (qs2 files) for given ma
-#' @param mae mae with dose-response data
+#' add intermediate data (qs2 files) for given MAE
+#' @param mae \code{MultiAssayExperiment} with dose-response data
 #' @param data_dir output directory
 #' @param steps character vector with pipeline steps for which 
 #'              intermediate data should be saved

--- a/R/utils.R
+++ b/R/utils.R
@@ -588,7 +588,7 @@ get_mae_from_intermediate_data <- function(data_dir) {
   checkmate::assert_directory(data_dir)
   
   last_step <- tail(get_pipeline_steps(), n = 1)
-  s_pattern <- paste0("__", last_step, ".qs")
+  s_pattern <- paste0("__", last_step, ".qs2")
   
   fpaths <- list.files(data_dir, pattern = s_pattern, full.names = TRUE)
   checkmate::assert_true(length(fpaths) > 0)
@@ -597,7 +597,7 @@ get_mae_from_intermediate_data <- function(data_dir) {
   
   for (fpath in fpaths) {
     exp_name <- sub(s_pattern, "", basename(fpath))
-    sel[[exp_name]] <- qs::qread(fpath)
+    sel[[exp_name]] <- qs2::qs_read(fpath)
   }
   MultiAssayExperiment::MultiAssayExperiment(experiments = sel)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -539,7 +539,7 @@ get_assays_per_pipeline_step <-
     ass
   }
 
-#' add intermediate data (qs files) for given ma
+#' add intermediate data (qs2 files) for given ma
 #' @param mae mae with dose-response data
 #' @param data_dir output directory
 #' @param steps character vector with pipeline steps for which 

--- a/R/utils.R
+++ b/R/utils.R
@@ -587,14 +587,17 @@ get_mae_from_intermediate_data <- function(data_dir) {
   
   checkmate::assert_directory(data_dir)
   
+  if (!requireNamespace("qs2", quietly = TRUE)) {
+    stop("Package 'qs2' is required to read intermediate data. Please install it.")
+  }
   last_step <- tail(get_pipeline_steps(), n = 1)
-  s_pattern <- paste0("__", last_step, ".qs2")
-  
+  s_pattern <- paste0("__", last_step, "\\.qs2$")
+
   fpaths <- list.files(data_dir, pattern = s_pattern, full.names = TRUE)
   checkmate::assert_true(length(fpaths) > 0)
-  
+
   sel <- list()
-  
+
   for (fpath in fpaths) {
     exp_name <- sub(s_pattern, "", basename(fpath))
     sel[[exp_name]] <- qs2::qs_read(fpath)

--- a/man/add_intermediate_data.Rd
+++ b/man/add_intermediate_data.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/utils.R
 \name{add_intermediate_data}
 \alias{add_intermediate_data}
-\title{add intermediate data (qs files) for given ma}
+\title{add intermediate data (qs2 files) for given ma}
 \usage{
 add_intermediate_data(mae, data_dir, steps = get_pipeline_steps())
 }
@@ -18,6 +18,6 @@ intermediate data should be saved}
 \code{NULL}
 }
 \description{
-add intermediate data (qs files) for given ma
+add intermediate data (qs2 files) for given ma
 }
 \keyword{internal}

--- a/man/add_intermediate_data.Rd
+++ b/man/add_intermediate_data.Rd
@@ -2,12 +2,12 @@
 % Please edit documentation in R/utils.R
 \name{add_intermediate_data}
 \alias{add_intermediate_data}
-\title{add intermediate data (qs2 files) for given ma}
+\title{add intermediate data (qs2 files) for given MAE}
 \usage{
 add_intermediate_data(mae, data_dir, steps = get_pipeline_steps())
 }
 \arguments{
-\item{mae}{mae with dose-response data}
+\item{mae}{\code{MultiAssayExperiment} with dose-response data}
 
 \item{data_dir}{output directory}
 
@@ -18,6 +18,6 @@ intermediate data should be saved}
 \code{NULL}
 }
 \description{
-add intermediate data (qs2 files) for given ma
+add intermediate data (qs2 files) for given MAE
 }
 \keyword{internal}

--- a/man/read_intermediate_data.Rd
+++ b/man/read_intermediate_data.Rd
@@ -2,12 +2,12 @@
 % Please edit documentation in R/pipeline_helpers.R
 \name{read_intermediate_data}
 \alias{read_intermediate_data}
-\title{read intermediate data for the given experiment and step to qs file}
+\title{read intermediate data for the given experiment and step to qs2 file}
 \usage{
 read_intermediate_data(path, step, experiment)
 }
 \arguments{
-\item{path}{string with the input directory of the qs file}
+\item{path}{string with the input directory of the qs2 file}
 
 \item{step, }{string with the step name}
 
@@ -17,6 +17,6 @@ read_intermediate_data(path, step, experiment)
 se
 }
 \description{
-read intermediate data for the given experiment and step to qs file
+read intermediate data for the given experiment and step to qs2 file
 }
 \keyword{internal}

--- a/man/runDrugResponseProcessingPipelineFxns.Rd
+++ b/man/runDrugResponseProcessingPipelineFxns.Rd
@@ -169,7 +169,7 @@ ectors) for \code{single-agent} and (optionally) for \code{combination} data}
 MultiAssayExperiment should be split again into appropriate data types}
 
 \item{data_dir}{string with the path to the directory with intermediate data
-of experiments (qs files). If set to NULL (default) intermediate data is not
+of experiments (qs2 files). If set to NULL (default) intermediate data is not
 saved/read in.}
 
 \item{partial_run}{logical flag indicating if the pipeline should be run
@@ -218,7 +218,7 @@ Pipeline can be run partially with \code{partial_run} flag set to TRUE. The
 \code{start_from} string defines the step from which the pipeline will be
 launched. However, partial run of the pipeline is possible only if the whole
 pipeline was launched at least once with defined \code{data_dir} and intermediate
-data was saved as qs files into \code{data_dir}.
+data was saved as qs2 files into \code{data_dir}.
 
 Pipeline can be run for the selected experiments by changing the default
 value of \code{selected_experiments} param. This scenario only works when

--- a/man/save_intermediate_data.Rd
+++ b/man/save_intermediate_data.Rd
@@ -2,12 +2,12 @@
 % Please edit documentation in R/pipeline_helpers.R
 \name{save_intermediate_data}
 \alias{save_intermediate_data}
-\title{save intermediate data for the given experiment and step to qs file}
+\title{save intermediate data for the given experiment and step to qs2 file}
 \usage{
 save_intermediate_data(path, step, experiment, se)
 }
 \arguments{
-\item{path}{string with the save directory for the qs file}
+\item{path}{string with the save directory for the qs2 file}
 
 \item{step, }{string with the step name}
 
@@ -19,6 +19,6 @@ save_intermediate_data(path, step, experiment, se)
 \code{NULL}
 }
 \description{
-save intermediate data for the given experiment and step to qs file
+save intermediate data for the given experiment and step to qs2 file
 }
 \keyword{internal}


### PR DESCRIPTION
# Description                                                                                                                                                                                                                                               
  ## What changed?                                                                                                                                                                                                                                            
  Related JIRA issue: GDR-3351                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                              
  Replaced all usage of the archived `qs` package with `qs2`:                                                                                                                                                                                                 
  - `qs::qread()` → `qs2::qs_read()`                                                                                                                                                                                                                          
  - `qs::qsave()` → `qs2::qs_save()`                                                                                                                                                                                                                          
  - File extensions updated from `.qs` to `.qs2`                                                                                                                                                                                                              
  - Dependency in DESCRIPTION updated accordingly                                                                                                                                                                                                             
  - Tests and vignettes updated to reflect the new API                                                                                                                                                                                                        
                                                                                                                                                                                                                                                              
  ## Why was it changed?                                                                                                                                                                                                                                      
  The `qs` package was archived on CRAN on January 17, 2026 and will not be included in Bioconductor 3.23.                                                                                                                                                    
  The `qs2` package is its official successor with an incompatible binary format.                                                                                                                                                                             
   
  # Checklist for sustainable code base                                                                                                                                                                                                                       
  - [X] I added tests for any code changed/added                                                                                                                                                                                                            
  - [X] I added documentation for any code changed/added                                                                                                                                                                                                      
  - [ ] I made sure naming of any new functions is self-explanatory and consistent                                                                                                                                                                          

  # Logistic checklist                                                                                                                                                                                                                                        
  - [X] Package version bumped
  - [X] Changelog updated                        