### PR TITLE
fix: replace STRING_PTR with STRING_PTR_RO for R-devel compatibility

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: gDRcore
 Title: Processing functions and interface to process and analyze drug
     dose-response data
-Version: 1.9.7
+Version: 1.9.8
 Date: 2026-02-18
 Authors@R: c(
     person("Bartosz", "Czech", , "bartosz.czech@contractors.roche.com", role = "aut",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## gDRcore 1.9.8 - 2026-04-27
+* fix C++ compilation error on R-devel (STRING_PTR → STRING_PTR_RO)
+
 ## gDRcore 1.9.7 - 2026-04-13
 * migrate from `qs` to `qs2` package (`qs::qread` → `qs2::qs_read`, `qs::qsave` → `qs2::qs_save`)
 * update checkpoint and generated data file extensions from `.qs` to `.qs2`

--- a/src/gDRcore.cpp
+++ b/src/gDRcore.cpp
@@ -39,9 +39,14 @@ extern "C" SEXP sortcpp(SEXP x) {
   case LGLSXP:
     std::sort(LOGICAL(x),LOGICAL(x)+LENGTH(x));
     break;
-  case STRSXP:
-    std::sort(const_cast<SEXP*>(STRING_PTR_RO(x)), const_cast<SEXP*>(STRING_PTR_RO(x)) + LENGTH(x), cmp_char);
+  case STRSXP: {
+    int n = LENGTH(x);
+    std::vector<SEXP> tmp(n);
+    for (int i = 0; i < n; ++i) tmp[i] = STRING_ELT(x, i);
+    std::sort(tmp.begin(), tmp.end(), cmp_char);
+    for (int i = 0; i < n; ++i) SET_STRING_ELT(x, i, tmp[i]);
     break;
+  }
   default:
     UNPROTECT(1);
   error_return("Unsupported type for sort.")

--- a/src/gDRcore.cpp
+++ b/src/gDRcore.cpp
@@ -40,7 +40,7 @@ extern "C" SEXP sortcpp(SEXP x) {
     std::sort(LOGICAL(x),LOGICAL(x)+LENGTH(x));
     break;
   case STRSXP:
-    std::sort(STRING_PTR(x), STRING_PTR(x) + LENGTH(x), cmp_char);
+    std::sort(const_cast<SEXP*>(STRING_PTR_RO(x)), const_cast<SEXP*>(STRING_PTR_RO(x)) + LENGTH(x), cmp_char);
     break;
   default:
     UNPROTECT(1);
@@ -76,8 +76,8 @@ struct CMP_REAL {
 };
 
 struct CMP_CHAR2 {
-  SEXP* start;
-  CMP_CHAR2(SEXP* start) : start(start) {};
+  const SEXP* start;
+  CMP_CHAR2(const SEXP* start) : start(start) {};
   bool operator()(int x, int y) {
     return strcmp(CHAR(*(start+x-1)),CHAR(*(start+y-1))) < 0; // shift compensates for difference between R and C indexing
   }
@@ -113,7 +113,7 @@ void internalOrder(int* index,SEXP x)
   }
   case STRSXP:
   {
-    SEXP* start = &STRING_PTR(x)[0];
+    const SEXP* start = STRING_PTR_RO(x);
     std::sort(index,index+LENGTH(x), CMP_CHAR2(start));
     break;
   }
@@ -280,8 +280,8 @@ extern "C" SEXP matches(SEXP a, SEXP b)
   }
   case STRSXP:
   {
-    SEXP* astart = &STRING_PTR(a)[0];
-    SEXP* bstart = &STRING_PTR(b)[0];
+    const SEXP* astart = STRING_PTR_RO(a);
+    const SEXP* bstart = STRING_PTR_RO(b);
     cmatch(astart,bstart,indexsA,indexsB,apoint,bpoint,alength,blength);
     break;
   }


### PR DESCRIPTION
 # Description                                                                                                                                                                                                                                               
  ## What changed?                                          
  * replace `STRING_PTR` with `STRING_PTR_RO` in `src/gDRcore.cpp`                                                                                                                                                                                            
                                                                                                                                                                                                                                                              
  Related JIRA issue: [GDR-3367](https://globaljira.roche.com/browse/GDR-3367)                                                                                                                                                                                
                                                                                                                                                                                                                                                              
  ## Why was it changed?                                                                                                                                                                                                                                      
  `STRING_PTR` was removed from the R C API in R-devel (Bioc 3.23).                                                                                                                                                                                           
  Linux build on Bioconductor failed with "STRING_PTR was not declared in this scope".
  macOS build was unaffected. Fix uses `STRING_PTR_RO` (read-only access) with                                                                                                                                                                                
  `const_cast` where in-place sorting requires mutable iterators.                                                                                                                                                                                             
                                                                                                                                                                                                                                                              
  # Checklist for sustainable code base                                                                                                                                                                                                                       
  - [x] I added tests for any code changed/added                                                                                                                                                                                                              
  - [x] I added documentation for any code changed/added                                                                                                                                                                                                      
  - [x] I made sure naming of any new functions is self-explanatory and consistent                                                                                                                                                                            
                                                                                  
  # Logistic checklist                                                                                                                                                                                                                                        
  - [x] Package version bumped                              
  - [x] Changelog updated                                         