### PR TITLE
GDR-3366: fix handling of NA Duration

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Type: Package
 Package: gDRcore
 Title: Processing functions and interface to process and analyze drug
     dose-response data
-Version: 1.9.8
-Date: 2026-02-18
+Version: 1.9.9
+Date: 2026-04-28
 Authors@R: c(
     person("Bartosz", "Czech", , "bartosz.czech@contractors.roche.com", role = "aut",
            comment = c(ORCID = "0000-0002-9908-3007")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## gDRcore 1.9.9 - 2026-04-28
+* fix handling of NA Duration in Day0 detection and GR value calculation
+
 ## gDRcore 1.9.8 - 2026-04-27
 * fix C++ compilation error on R-devel (STRING_PTR → STRING_PTR_RO)
 

--- a/R/calculate_GR_value.R
+++ b/R/calculate_GR_value.R
@@ -92,7 +92,7 @@ calculate_GR_value <- function(rel_viability,
   if (any(is.na(day0_readout))) {
     ## Back-calculate the day0_readout using the reference doubling time 
     ## and the duration of treatment.
-    GRvalue <- if (is.null(ref_div_time) || is.na(ref_div_time)) {
+    GRvalue <- if (is.null(ref_div_time) || is.na(ref_div_time) || is.null(duration) || is.na(duration)) {
       rep(NA, length(rel_viability))
     } else if (ref_div_time > 1.5 * duration) {
       rep(NA, length(rel_viability))

--- a/R/create_SE.R
+++ b/R/create_SE.R
@@ -212,7 +212,7 @@ create_SE <- function(df_,
     
     day0_ref <- ctl_maps[["Day0"]][[trt]]
     day0_df <- untreated[untreated$rn %chin% day0_ref]
-    isDay0 <- day0_df[[gDRutils::get_env_identifiers("duration")]] == 0
+    isDay0 <- day0_df[[gDRutils::get_env_identifiers("duration")]] %in% 0
     
     day0_df <- day0_df[isDay0, untrt_cols, with = FALSE]
     day0_df <- if (nrow(day0_df) == 0) {

--- a/R/identify_keys.R
+++ b/R/identify_keys.R
@@ -114,7 +114,7 @@ identify_keys <- function(df_,
     if (all(is.na(df_[, k, with = FALSE]))) {
       keys <- gDRutils::loop(keys, function(x) setdiff(x, k))
     }
-    if (all(is.na(df_[which(t0), k, with = FALSE]))) {
+    if (any(t0) && all(is.na(df_[which(t0), k, with = FALSE]))) {
       keys[["Day0"]] <- setdiff(keys[["Day0"]], k)
     }
   }

--- a/R/identify_keys.R
+++ b/R/identify_keys.R
@@ -108,13 +108,18 @@ identify_keys <- function(df_,
   keys$untreated_tag <- identifiers$untreated_tag
 
   t0 <- df_[[duration_col]] %in% 0
+  has_day0 <- any(t0)
   # Remove keys where all values are NA.
   # TODO: Improve this.
   for (k in keys[["untrt_Endpoint"]]) {
     if (all(is.na(df_[, k, with = FALSE]))) {
+      saved_day0 <- keys[["Day0"]]
       keys <- gDRutils::loop(keys, function(x) setdiff(x, k))
+      if (!has_day0) {
+        keys[["Day0"]] <- saved_day0
+      }
     }
-    if (any(t0) && all(is.na(df_[which(t0), k, with = FALSE]))) {
+    if (has_day0 && all(is.na(df_[which(t0), k, with = FALSE]))) {
       keys[["Day0"]] <- setdiff(keys[["Day0"]], k)
     }
   }

--- a/R/identify_keys.R
+++ b/R/identify_keys.R
@@ -107,7 +107,7 @@ identify_keys <- function(df_,
   keys$duration <- duration_col 
   keys$untreated_tag <- identifiers$untreated_tag
 
-  t0 <- df_[, duration_col, with = FALSE] == 0
+  t0 <- df_[[duration_col]] %in% 0
   # Remove keys where all values are NA.
   # TODO: Improve this.
   for (k in keys[["untrt_Endpoint"]]) {

--- a/R/map_df.R
+++ b/R/map_df.R
@@ -61,7 +61,7 @@ map_df <- function(trt_md,
   ))
   
   if (ref_type == "Day0") {
-    ref_md <- ref_md[get(duration_col) == 0, ]
+    ref_md <- ref_md[get(duration_col) %in% 0, ]
   }
   
   conc <- cbind(array(0, nrow(ref_md)), 
@@ -69,7 +69,7 @@ map_df <- function(trt_md,
   is_ref_conc <- rowSums(conc == 0) == ncol(conc)
   
   if (ref_type == "Day0") {
-    matching_list <- list(T0 = ref_md[[duration_col]] == 0, conc = is_ref_conc)
+    matching_list <- list(T0 = ref_md[[duration_col]] %in% 0, conc = is_ref_conc)
     matchFactor <- "T0"
   } else if (ref_type == "untrt_Endpoint") {
     matching_list <- list(conc = is_ref_conc)

--- a/tests/testthat/test-calculate_GR_value.R
+++ b/tests/testthat/test-calculate_GR_value.R
@@ -64,6 +64,18 @@ test_that("calculate_GR_value works as expected", {
     ref_div_time = (duration * 1.5) + 1
   )
   expect_true(all(is.na(gr4)))
+
+  # day0_readout is NA, duration is NA (e.g. PRISM data).
+  gr5 <- calculate_GR_value(
+    rel_viability = rv,
+    corrected_readout = corrected,
+    day0_readout = NA,
+    untrt_readout = untrt,
+    ndigit_rounding = 4,
+    duration = NA_real_,
+    ref_div_time = duration / 2
+  )
+  expect_true(all(is.na(gr5)))
 })
 
 test_that("calculate_GR_value throws expected errors", {

--- a/tests/testthat/test-identify_keys.R
+++ b/tests/testthat/test-identify_keys.R
@@ -54,4 +54,9 @@ test_that("identify_keys works", {
   df_$E2 <- NA
   k3 <- identify_keys(df_, nested_keys = NULL)
   expect_equal(setdiff(k1[["untrt_Endpoint"]], k3[["untrt_Endpoint"]]), "E2")
+
+  # NA Duration should not be treated as Day0.
+  df_$Duration <- NA_real_
+  k4 <- identify_keys(df_, nested_keys = NULL)
+  expect_equal(sort(k4[["Day0"]]), sort(c(cl, misc)))
 })


### PR DESCRIPTION
# Description
## What changed?
Related JIRA issue: GDR-3366

Replace `== 0` with `%in% 0` for Duration comparisons in Day0 detection, and add `is.na(duration)` guard in GR value back-calculation.

## Why was it changed?
Follow-up to gDRimport#119 — Duration can now be `NA_real_` and must be handled gracefully throughout the pipeline.

# Checklist for sustainable code base
- [x] I added tests for any code changed/added
- [x] I added documentation for any code changed/added
- [x] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [x] Package version bumped
- [x] Changelog updated