### PR TITLE
chore: sync main with Bioconductor devel (GDR-3372)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: gDRcore
 Title: Processing functions and interface to process and analyze drug
     dose-response data
-Version: 1.9.8
+Version: 1.10.0
 Date: 2026-02-18
 Authors@R: c(
     person("Bartosz", "Czech", , "bartosz.czech@contractors.roche.com", role = "aut",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: gDRcore
 Title: Processing functions and interface to process and analyze drug
     dose-response data
-Version: 1.10.0
+Version: 1.11.0
 Date: 2026-02-18
 Authors@R: c(
     person("Bartosz", "Czech", , "bartosz.czech@contractors.roche.com", role = "aut",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Type: Package
 Package: gDRcore
 Title: Processing functions and interface to process and analyze drug
     dose-response data
-Version: 1.11.0
-Date: 2026-02-18
+Version: 1.11.1
+Date: 2026-04-29
 Authors@R: c(
     person("Bartosz", "Czech", , "bartosz.czech@contractors.roche.com", role = "aut",
            comment = c(ORCID = "0000-0002-9908-3007")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## gDRcore 1.11.1 - 2026-04-29
+* synchronize Bioconductor and GitHub versioning
+
 ## gDRcore 1.9.8 - 2026-04-27
 * fix C++ compilation error on R-devel (STRING_PTR → STRING_PTR_RO)
 


### PR DESCRIPTION
# Description
## What changed?
Related JIRA issue: https://globaljira.roche.com/browse/GDR-3372

Synced `main` branch with Bioconductor `upstream/devel`. Changes: version bumped to 1.11.1, NEWS.md and DESCRIPTION date updated.

## Why was it changed?
Bioconductor created RELEASE_3_23 branch - maintainers required to sync GitHub with Bioconductor git server.

# Checklist for sustainable code base
- [x] I added tests for any code changed/added (N/A - version bump only)
- [x] I added documentation for any code changed/added (N/A)
- [x] I made sure naming of any new functions is self-explanatory and consistent (N/A)

# Logistic checklist
- [x] Package version bumped
- [x] Changelog updated

# Screenshots (optional)