### PR TITLE
GDR-3420: allow custom annotations in merge_data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: gDRcore
 Title: Processing functions and interface to process and analyze drug
     dose-response data
-Version: 1.11.4
+Version: 1.11.5
 Date: 2026-05-27
 Authors@R: c(
     person("Bartosz", "Czech", , "czech.bartosz@external.gene.com", role = "aut",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## gDRcore 1.11.5 - 2026-06-08
+* allow custom annotations in `merge_data` and `cleanup_metadata`
+
 ## gDRcore 1.11.4 - 2026-05-27
 * apply updated gDRstyle rules
 

--- a/R/merge_data.R
+++ b/R/merge_data.R
@@ -33,6 +33,8 @@ merge_data <- function(manifest, treatments, data,
   # Assertions:
   checkmate::assert_data_table(manifest)
   checkmate::assert_data_table(treatments)
+  checkmate::assert_data_table(cell_line_annotation, null.ok = TRUE)
+  checkmate::assert_data_table(drug_annotation, null.ok = TRUE)
   checkmate::assert_data_table(data)
 
   futile.logger::flog.info("Merging data")

--- a/R/merge_data.R
+++ b/R/merge_data.R
@@ -5,6 +5,10 @@
 #' @param manifest a data.table with a manifest info
 #' @param treatments a data.table with a treaatments info
 #' @param data a data.table with a raw data info
+#' @param cell_line_annotation optional data.table with cell line annotations;
+#'   if NULL (default), annotations are looked up from gDRinternal or gDRtestData
+#' @param drug_annotation optional data.table with drug annotations;
+#'   if NULL (default), annotations are looked up from gDRinternal or gDRtestData
 #'
 #' @examples
 #' td <- gDRimport::get_test_data()
@@ -23,7 +27,9 @@
 #' @keywords merge_data
 #' @export
 #'
-merge_data <- function(manifest, treatments, data) {
+merge_data <- function(manifest, treatments, data,
+                       cell_line_annotation = NULL,
+                       drug_annotation = NULL) {
   # Assertions:
   checkmate::assert_data_table(manifest)
   checkmate::assert_data_table(treatments)
@@ -120,7 +126,9 @@ merge_data <- function(manifest, treatments, data) {
     mget(expected_headers))]
 
   # clean up the metadata
-  cleanedup_metadata <- cleanup_metadata(df_metadata_trimmed)
+  cleanedup_metadata <- cleanup_metadata(df_metadata_trimmed,
+                                          cell_line_annotation = cell_line_annotation,
+                                          drug_annotation = drug_annotation)
   # should not happen
   stopifnot(NROW(cleanedup_metadata) == NROW(df_metadata_trimmed))
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -53,6 +53,8 @@ cleanup_metadata <- function(df_metadata,
 
   # Assertions:
   checkmate::assert_data_table(df_metadata)
+  checkmate::assert_data_table(cell_line_annotation, null.ok = TRUE)
+  checkmate::assert_data_table(drug_annotation, null.ok = TRUE)
 
   # Round duration to 6 values.
   duration_id <- gDRutils::get_env_identifiers("duration")

--- a/R/utils.R
+++ b/R/utils.R
@@ -27,6 +27,10 @@
 #' Cleanup a data.table with metadata
 #'
 #' @param df_metadata a data.table with metadata
+#' @param cell_line_annotation optional data.table with cell line annotations;
+#'   if NULL (default), annotations are looked up from gDRinternal or gDRtestData
+#' @param drug_annotation optional data.table with drug annotations;
+#'   if NULL (default), annotations are looked up from gDRinternal or gDRtestData
 #'
 #' @examples
 #'
@@ -43,7 +47,9 @@
 #' @keywords utils
 #' @export
 #'
-cleanup_metadata <- function(df_metadata) {
+cleanup_metadata <- function(df_metadata,
+                             cell_line_annotation = NULL,
+                             drug_annotation = NULL) {
 
   # Assertions:
   checkmate::assert_data_table(df_metadata)
@@ -53,8 +59,13 @@ cleanup_metadata <- function(df_metadata) {
   df_metadata[[duration_id]] <- round(as.numeric(df_metadata[[duration_id]], 6))
 
   if (!gDRutils::get_env_identifiers("cellline_name") %in% names(df_metadata)) {
+    cl_ann <- if (!is.null(cell_line_annotation)) {
+      cell_line_annotation
+    } else {
+      get_cell_line_annotation(df_metadata)
+    }
     df_metadata <- annotate_dt_with_cell_line(df_metadata,
-                                              cell_line_annotation = get_cell_line_annotation(df_metadata))
+                                              cell_line_annotation = cl_ann)
   }
 
   drug_conc_cols <- unlist(
@@ -114,8 +125,13 @@ cleanup_metadata <- function(df_metadata) {
   }
 
   if (!gDRutils::get_env_identifiers("drug_name") %in% names(df_metadata)) {
+    dr_ann <- if (!is.null(drug_annotation)) {
+      drug_annotation
+    } else {
+      get_drug_annotation(df_metadata)
+    }
     df_metadata <- annotate_dt_with_drug(df_metadata,
-                                         drug_annotation = get_drug_annotation(df_metadata))
+                                         drug_annotation = dr_ann)
   }
   df_metadata
 }

--- a/man/cleanup_metadata.Rd
+++ b/man/cleanup_metadata.Rd
@@ -4,10 +4,20 @@
 \alias{cleanup_metadata}
 \title{cleanup_metadata}
 \usage{
-cleanup_metadata(df_metadata)
+cleanup_metadata(
+  df_metadata,
+  cell_line_annotation = NULL,
+  drug_annotation = NULL
+)
 }
 \arguments{
 \item{df_metadata}{a data.table with metadata}
+
+\item{cell_line_annotation}{optional data.table with cell line annotations;
+if NULL (default), annotations are looked up from gDRinternal or gDRtestData}
+
+\item{drug_annotation}{optional data.table with drug annotations;
+if NULL (default), annotations are looked up from gDRinternal or gDRtestData}
 }
 \value{
 a data.table with cleaned metadata

--- a/man/merge_data.Rd
+++ b/man/merge_data.Rd
@@ -4,7 +4,13 @@
 \alias{merge_data}
 \title{merge_data}
 \usage{
-merge_data(manifest, treatments, data)
+merge_data(
+  manifest,
+  treatments,
+  data,
+  cell_line_annotation = NULL,
+  drug_annotation = NULL
+)
 }
 \arguments{
 \item{manifest}{a data.table with a manifest info}
@@ -12,6 +18,12 @@ merge_data(manifest, treatments, data)
 \item{treatments}{a data.table with a treaatments info}
 
 \item{data}{a data.table with a raw data info}
+
+\item{cell_line_annotation}{optional data.table with cell line annotations;
+if NULL (default), annotations are looked up from gDRinternal or gDRtestData}
+
+\item{drug_annotation}{optional data.table with drug annotations;
+if NULL (default), annotations are looked up from gDRinternal or gDRtestData}
 }
 \value{
 a data.table with merged data and metadata.


### PR DESCRIPTION
# Description
## What changed?
Related JIRA issue: GDR-3420

Add optional `cell_line_annotation` and `drug_annotation` parameters to `merge_data()` and `cleanup_metadata()`. When provided, these bypass the automatic package-based lookup (gDRinternal/gDRtestData).

## Why was it changed?
Open-source users without `gDRinternal` hit assertion failures because gDRtestData fallback doesn't contain real annotations. This allows users to pass their own annotation data.tables directly.

# Checklist for sustainable code base
- [ ] I added tests for any code changed/added
- [x] I added documentation for any code changed/added
- [x] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [ ] Package version bumped
- [ ] Changelog updated