### PR TITLE
fix: remove checkerboard artifact on combo single-agent arms

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Type: Package
 Package: gDRcore
 Title: Processing functions and interface to process and analyze drug
     dose-response data
-Version: 1.11.5
-Date: 2026-05-27
+Version: 1.11.7
+Date: 2026-07-20
 Authors@R: c(
     person("Bartosz", "Czech", , "czech.bartosz@external.gene.com", role = "aut",
            comment = c(ORCID = "0000-0002-9908-3007")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## gDRcore 1.11.7 - 2026-07-20
+* fix non-monotonic ("checkerboard") smoothed combo response on single-agent arms by using only the parallel fit along each arm
+
 ## gDRcore 1.11.6 - 2026-06-11
 * improve pipeline performance by removing redundant data copies, enabling parallel averaging, and vectorizing NA-filling
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,5 @@
 ## gDRcore 1.11.7 - 2026-07-20
-* fix non-monotonic ("checkerboard") smoothed combo response on single-agent arms by using only the parallel fit along each arm
+* fix non-monotonic ("checkerboard") response on combo single-agent arms by using only the parallel fit
 
 ## gDRcore 1.11.6 - 2026-06-11
 * improve pipeline performance by removing redundant data copies, enabling parallel averaging, and vectorizing NA-filling

--- a/R/fit_SE.combinations.R
+++ b/R/fit_SE.combinations.R
@@ -241,7 +241,28 @@ fit_SE.combinations <- function(se,
       # store the values from the Averaged assay for reference
       complete_subset$av_values <- complete_subset$x
       # and replace by the Smoothed values
-      complete_subset$smooth <- rowMeans(mat, na.rm = TRUE)
+      smooth_values <- rowMeans(mat, na.rm = TRUE)
+
+      # On the single-agent arms use only the fit run ALONG that arm. The
+      # perpendicular fit contributes its intercept (x_0) at the arm, which is
+      # an unreliable extrapolation: when the orthogonal series is not
+      # statistically significant, fit_curves collapses it to a constant equal
+      # to the row/column mean and overrides the intended reference. These
+      # collapsed intercepts vary non-monotonically along the arm and, once
+      # averaged into 'smooth', produce a checkerboard/zig-zag response surface
+      # (most visible on flat/shallow curves). Restricting each arm to its
+      # parallel fit removes the artifact and leaves the matrix interior
+      # unchanged. Falls back to the averaged value where the parallel fit is
+      # unavailable (NA).
+      if ("col_values" %in% colnames(complete_subset)) {
+        on_arm_1 <- complete_subset[[id2]] == 0 & !is.na(complete_subset$col_values)
+        smooth_values[on_arm_1] <- complete_subset$col_values[on_arm_1]
+      }
+      if ("row_values" %in% colnames(complete_subset)) {
+        on_arm_2 <- complete_subset[[id]] == 0 & !is.na(complete_subset$row_values)
+        smooth_values[on_arm_2] <- complete_subset$row_values[on_arm_2]
+      }
+      complete_subset$smooth <- smooth_values
 
       # just keep the relevant columns and change to the metric name
       cols <- c(id, id2, "smooth")

--- a/R/fit_SE.combinations.R
+++ b/R/fit_SE.combinations.R
@@ -254,12 +254,14 @@ fit_SE.combinations <- function(se,
       # parallel fit removes the artifact and leaves the matrix interior
       # unchanged. Falls back to the averaged value where the parallel fit is
       # unavailable (NA).
+      # use which() so any NA in the concentration column is dropped rather
+      # than producing NA subscripts (illegal on the LHS of an assignment)
       if ("col_values" %in% colnames(complete_subset)) {
-        on_arm_1 <- complete_subset[[id2]] == 0 & !is.na(complete_subset$col_values)
+        on_arm_1 <- which(complete_subset[[id2]] == 0 & !is.na(complete_subset$col_values))
         smooth_values[on_arm_1] <- complete_subset$col_values[on_arm_1]
       }
       if ("row_values" %in% colnames(complete_subset)) {
-        on_arm_2 <- complete_subset[[id]] == 0 & !is.na(complete_subset$row_values)
+        on_arm_2 <- which(complete_subset[[id]] == 0 & !is.na(complete_subset$row_values))
         smooth_values[on_arm_2] <- complete_subset$row_values[on_arm_2]
       }
       complete_subset$smooth <- smooth_values

--- a/tests/testthat/test-fit_SE.R
+++ b/tests/testthat/test-fit_SE.R
@@ -63,3 +63,31 @@ test_that("fit_SE.combinations works as expected", {
     BumpyMatrix::unsplitAsDataFrame(SummarizedExperiment::assay(new_se1$result, "all_iso_points"))
   expect_true(all(dim(aip_df) > 0))
 })
+
+test_that("fit_SE.combinations single-agent arms are monotonic (no checkerboard)", {
+
+  fmae_cms <- gDRutils::get_synthetic_data("finalMAE_combo_matrix_small")
+  se1 <- fmae_cms[[gDRutils::get_supported_experiments("combo")]]
+  SummarizedExperiment::assays(se1) <- SummarizedExperiment::assays(se1)["Averaged"]
+
+  fit <- purrr::quietly(fit_SE.combinations)(se1[1, 1])$result
+  ex <- data.table::as.data.table(
+    BumpyMatrix::unsplitAsDataFrame(SummarizedExperiment::assay(fit, "excess")))
+
+  # On each single-agent arm the smoothed response must be monotonically
+  # non-increasing with concentration. Averaging the perpendicular fit's
+  # intercept into 'smooth' (it collapses to the row/column mean when the
+  # orthogonal series is not significant) used to make the arm zig-zag -
+  # the "checkerboard" artifact. Each arm now uses only its parallel fit.
+  tol <- 1e-6
+  for (nt in unique(ex$normalization_type)) {
+    arm1 <- ex[Concentration_2 == 0 & normalization_type == nt & !is.na(smooth)][
+      order(Concentration)]
+    arm2 <- ex[Concentration == 0 & normalization_type == nt & !is.na(smooth)][
+      order(Concentration_2)]
+    expect_true(all(diff(arm1$smooth) <= tol),
+                info = paste("drug_1 single-agent arm not monotonic for", nt))
+    expect_true(all(diff(arm2$smooth) <= tol),
+                info = paste("drug_2 single-agent arm not monotonic for", nt))
+  }
+})


### PR DESCRIPTION
# Description
## What changed?
On the single-agent arms of a combination matrix, the smoothed response (`smooth` in `fit_SE.combinations`) now uses only the fit run **along** that arm (`col_values` for the drug_1 arm, `row_values` for the drug_2 arm) instead of averaging in the raw value and the perpendicular fit's intercept. Falls back to the previous averaged value where the parallel fit is unavailable.

Related JIRA issue: GDR-3484

## Why was it changed?
The perpendicular fit contributes its intercept (`x_0`) at the arm, which is an unreliable extrapolation: when the orthogonal series is not statistically significant, `fit_curves` collapses it to a constant equal to the row/column mean and overrides the intended reference. These collapsed intercepts vary non-monotonically along the arm and, once averaged into `smooth`, produce a non-monotonic ("checkerboard") response surface (most visible on flat/shallow curves).

Note for reviewers: the single-agent arms are the HSA/Bliss single-agent reference, so this corrects that reference and therefore shifts combination excess/scores. On real data the change is mostly a small increase in synergy (median ΔHSA ~+0.01, up to ~+0.06), concentrated exactly in the cells that previously showed the arm artifact — i.e. the artifact had been suppressing the reference and hiding synergy. The matrix interior `smooth` values are unchanged.

# Checklist for sustainable code base
- [x] I added tests for any code changed/added
- [x] I added documentation for any code changed/added
- [x] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [x] Package version bumped
- [x] Changelog updated
