### PR TITLE
test: skip pipeline test when qs2 is not installed (GDR-3512)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Type: Package
 Package: gDRcore
 Title: Processing functions and interface to process and analyze drug
     dose-response data
-Version: 1.11.7
-Date: 2026-07-20
+Version: 1.11.8
+Date: 2026-08-04
 Authors@R: c(
     person("Bartosz", "Czech", , "czech.bartosz@external.gene.com", role = "aut",
            comment = c(ORCID = "0000-0002-9908-3007")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## gDRcore 1.11.8 - 2026-08-04
+* skip pipeline integration test when `qs2` is not installed (GDR-3512)
+
 ## gDRcore 1.11.7 - 2026-07-20
 * fix non-monotonic ("checkerboard") response on combo single-agent arms by using only the parallel fit
 

--- a/tests/testthat/test-runDrugResponseProcessingPipeline.R
+++ b/tests/testthat/test-runDrugResponseProcessingPipeline.R
@@ -10,6 +10,7 @@ test_that("paste_warnings works as expected", {
 
 
 test_that("main pipeline functions works as expected", {
+  testthat::skip_if_not_installed("qs2")
   p_dir <- file.path(tempdir(), "pcheck")
   suppressWarnings(dir.create(p_dir))
   on.exit(unlink(p_dir, TRUE))


### PR DESCRIPTION
## Problem

Bioconductor builders install only hard dependencies (`Imports`/`Depends`), not `Suggests`. `qs2` is listed in `Suggests` in gDRcore, so it is absent on Bioc build machines. When `runDrugResponseProcessingPipeline()` is called with `data_dir` set, it calls `save_intermediate_data()` internally, which calls `stop()` when `qs2` is not available — causing an ERROR in CHECK on both devel and release.

This is one of two root causes tracked in GDR-3512. The other (stringfish/TBB ABI mismatch with RcppParallel 6.0.0) is an upstream issue ([stringfish#26](https://github.com/traversc/stringfish/issues/26)) and will resolve once stringfish is rebuilt on Bioc infrastructure.

## Fix

Add `testthat::skip_if_not_installed("qs2")` at the start of the test block that exercises the `data_dir` code path. The test is skipped gracefully when `qs2` is absent, rather than failing with a misleading stop message.