### PR TITLE
fix: keep create_SE working for time-course data

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Type: Package
 Package: gDRcore
 Title: Processing functions and interface to process and analyze drug
     dose-response data
-Version: 1.11.9
-Date: 2026-08-12
+Version: 1.11.10
+Date: 2026-08-17
 Authors@R: c(
     person("Bartosz", "Czech", , "czech.bartosz@external.gene.com", role = "aut",
            comment = c(ORCID = "0000-0002-9908-3007")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## gDRcore 1.11.10 - 2026-08-17
+* fix `create_SE()` for time-course data, where the duration is a nested identifier
+  and therefore absent from the control metadata
+
 ## gDRcore 1.11.9 - 2026-08-12
 * refactor fit_SE.combinations() into composable apply_combo_*() steps
 

--- a/R/map_df.R
+++ b/R/map_df.R
@@ -60,8 +60,16 @@ map_df <- function(trt_md,
     simplify = FALSE
   ))
 
+  # Day0 controls are the reference rows measured at Duration == 0. For
+  # time-course data the duration is a nested identifier, so it never reaches
+  # the reference metadata and no Day0 control can be selected from it.
+  has_duration <- duration_col %in% names(ref_md)
   if (ref_type == "Day0") {
-    ref_md <- ref_md[get(duration_col) %in% 0, ]
+    if (has_duration) {
+      ref_md <- ref_md[get(duration_col) %in% 0, ]
+    } else {
+      ref_md <- ref_md[0L, ]
+    }
   }
 
   conc <- cbind(array(0, NROW(ref_md)),
@@ -69,7 +77,12 @@ map_df <- function(trt_md,
   is_ref_conc <- rowSums(conc == 0) == NCOL(conc)
 
   if (ref_type == "Day0") {
-    matching_list <- list(T0 = ref_md[[duration_col]] %in% 0, conc = is_ref_conc)
+    if (has_duration) {
+      is_t0 <- ref_md[[duration_col]] %in% 0
+    } else {
+      is_t0 <- logical(NROW(ref_md))
+    }
+    matching_list <- list(T0 = is_t0, conc = is_ref_conc)
     matchFactor <- "T0"
   } else if (ref_type == "untrt_Endpoint") {
     matching_list <- list(conc = is_ref_conc)

--- a/tests/testthat/test-map_df.R
+++ b/tests/testthat/test-map_df.R
@@ -115,3 +115,32 @@ test_that(".get_untreated_tag_count helper and assertions work", {
   expect_error(.get_untreated_tag_count(dt_valid, drug_identifier_keys = "drug"),
                "None of the drug")
 })
+
+test_that("map_df tolerates reference metadata without a duration column", {
+  # Time-course data keeps the duration inside the BumpyMatrix cells, so it is
+  # a nested identifier and never reaches the reference metadata. Day0 controls
+  # cannot be selected in that case, but mapping must not fail.
+  md_df <- data.table::data.table(
+    Gnumber = rep(c("vehicle", "G1"), each = 4),
+    DrugName = rep(c("vehicle", "GN1"), each = 4),
+    clid = paste0("C", rep_len(seq(2), 8)),
+    CellLineName = paste0("N", rep_len(seq(2), 8)),
+    Concentration = rep(c(0, 1), each = 4),
+    rn = as.character(seq_len(8))
+  )
+  ref_df <- md_df[Gnumber == "vehicle", ]
+  trt_df <- md_df[Gnumber != "vehicle", ]
+  ref_cols <- c("clid", "CellLineName")
+
+  expect_error(
+    day0 <- map_df(trt_df, ref_df, ref_cols = ref_cols, ref_type = "Day0"),
+    NA
+  )
+  expect_equal(length(day0), NROW(trt_df))
+  expect_true(all(lengths(day0) == 0L))
+
+  # The endpoint controls do not depend on the duration column at all
+  endpoint <- map_df(trt_df, ref_df, ref_cols = ref_cols, ref_type = "untrt_Endpoint")
+  expect_equal(length(endpoint), NROW(trt_df))
+  expect_true(any(lengths(endpoint) > 0L))
+})


### PR DESCRIPTION
# Description
## What changed?

`create_SE(data_type = "time-course")` currently fails for every time-course dataset:

```
Error in .checkTypos(e, names_x) :
  Object 'Duration' not found amongst [clid, CellLineName, Tissue, parental_identifier,
  subtype, ReferenceDivisionTime, col_id, Gnumber, DrugName, drug_moa, ...]
```

The traceback runs `create_SE()` → `gDRutils::loop(controls, ...)` → `map_df()` → `ref_md[get(duration_col) %in% 0, ]`.

Root cause: the time-course nested identifiers were changed from `(concentration, concentration2)` to `(concentration, duration)`. That is the right call — the duration varies inside a BumpyMatrix cell — but it also takes the duration column out of `rowData`/`colData`, so the reference metadata passed to `map_df()` no longer has it, while the Day0 filter reads it unconditionally.

`map_df()` now treats a missing duration column as "no Day0 controls can be selected here" instead of failing. That matches the semantics: Day0 controls are reference rows measured at duration zero, and for time-course data `create_SE()` maps an empty untreated table to begin with, so the filter never had anything to select.

## Why was it changed?

The whole time-course pipeline (import → SE → normalize → analysis report) cannot run on `main`. Only the last, already-processed stage can be re-rendered from an existing MAE.

### Files
- `R/map_df.R` — guard the Day0 duration filter
- `tests/testthat/test-map_df.R` — regression test: reference metadata without a duration column maps without error, returns no Day0 match, and endpoint controls still map

## Does this touch single-agent / combination data?

No. The new branch only runs when the duration column is missing from the reference metadata; with the column present the code is the one that was there before.

For single-agent and combination data the duration cannot be missing: it is part of `REQ_COL_IDENTIFIERS` in gDRutils, and it stays in `rowData`/`colData` because it is not a nested identifier for those data types. Only time-course moves it into the BumpyMatrix cells, which is exactly the case that used to crash.

The semantics also match what `create_SE()` already does two calls downstream (`R/create_SE.R`), which has carried the same guard all along:

```r
if (duration_col %in% names(untreated)) {
  day0_eligible_rn <- untreated[get(duration_col) %in% 0, "rn"][[1L]]
} else {
  day0_eligible_rn <- character(0)
}
```

So "no duration column means no Day0 controls" was already the intended behaviour of the pipeline; `map_df()` was the one place that errored instead.

## Validation

- `test-map_df.R`: 21 tests pass
- Golden-file suites for the standard data types pass unchanged: `test-finalMAE_small_no_noise.R`, `test-finalMAE_wLigand.R`, `test-cotreatments.R`, `test-codilutions.R`
- `test-create_SE.R` and `test-runDrugResponseProcessingPipeline.R` fail only on the pre-existing "Google Token not found" environment error, identically to `main`
- `create_SE(data_type = "time-course")` was run against the step 1 output of two independent time-course datasets, both of which fail on `main` and succeed with this change
- lint and NEWS checks clean

### Regression run against `main`

The full `runDrugResponseProcessingPipeline()` was run on three datasets (a small drug combination screen, a large one, and a single-agent PRISM subset) with the installed `main` build and with this branch, then compared cell by cell across **every** assay — `RawTreated`, `Controls`, `Normalized`, `Averaged`, `Metrics`, `excess`, `isobolograms`, `all_iso_points`, `scores`:

```
worst max|delta| across everything: 0.000e+00
mismatching cells: 0
non-numeric columns identical: TRUE (all assays)
```

So single-agent and combination output is bit-for-bit unchanged.

On the time-course side the report pipeline now gets past the failure: steps 1-2 complete on a real incucyte dataset and produce the expected `RawTreated` / `Controls` / `LogFoldChange` assays, where step 2 previously aborted in `create_SE()`.

# Checklist for sustainable code base
- [x] I added tests for any code changed/added
- [x] I added documentation for any code changed/added
- [x] I made sure naming of any new functions is self-explanatory and consistent

# Logistic checklist
- [x] Package version bumped (1.11.10)
- [x] Changelog updated
